### PR TITLE
Updated exports so that readme becomes correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Create a new `.xml.js` or `.xml.ts` file in your Astro pages directory to genera
 // src/pages/atom.xml.js
 import atom from 'astrojs-atom';
 
-// Alternatively you can export it explicitly
+// Alternatively you can import the function explicitly
 // import { getAtomResponse } from 'astrojs-atom';
 
 export function GET(context) {

--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ Create a new `.xml.js` or `.xml.ts` file in your Astro pages directory to genera
 
 ```typescript
 // src/pages/atom.xml.js
-import { getAtomResponse } from 'astrojs-atom';
+import atom from 'astrojs-atom';
+
+// Alternatively you can export it explicitly
+// import { getAtomResponse } from 'astrojs-atom';
 
 export function GET(context) {
-  return getAtomResponse({
+  return atom({ // Alternatively: `return getAtomResponse({`
     // Required: Feed metadata
     title: "My Website",
     id: "https://example.com/",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Create a new `.xml.js` or `.xml.ts` file in your Astro pages directory to genera
 // src/pages/atom.xml.js
 import { getAtomResponse } from 'astrojs-atom';
 
-export async function GET(context) {
+export function GET(context) {
   return getAtomResponse({
     // Required: Feed metadata
     title: "My Website",

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,7 @@ function serializeContentConstruct(
   };
 }
 
-export default async function getAtomResponse(atomOptions: AtomFeedOptions): Promise<Response> {
+export async function getAtomResponse(atomOptions: AtomFeedOptions): Promise<Response> {
   const atomString = await getAtomString(atomOptions);
   const contentType = atomOptions.useLegacyXmlContentType
     ? 'application/xml; charset=utf-8'
@@ -254,6 +254,8 @@ export default async function getAtomResponse(atomOptions: AtomFeedOptions): Pro
     },
   });
 }
+
+export default getAtomResponse;
 
 export async function getAtomString(atomOptions: AtomFeedOptions): Promise<string> {
   // Extract non-schema options

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,0 +1,6 @@
+import atom, { getAtomResponse } from '../src/index';
+import { expect, test } from "vitest";
+
+test('getAromResponse is usable both as an explicit import and in @astrojs/rss-compatible fasion', () => {
+    expect(atom).toStrictEqual(getAtomResponse);
+});

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,6 +1,6 @@
-import atom, { getAtomResponse } from '../src/index';
+import atom, { getAtomResponse } from "../src/index";
 import { expect, test } from "vitest";
 
-test('getAromResponse is usable both as an explicit import and in @astrojs/rss-compatible fasion', () => {
-    expect(atom).toStrictEqual(getAtomResponse);
+test('getAtomResponse is usable both as an explicit import and in @astrojs/rss-compatible fashion', () => {
+    expect(atom).toBe(getAtomResponse);
 });


### PR DESCRIPTION
Currently, README is inconsistent with the actual code. This PR updates exports so that `getAtomResponse` can be used as an explicit sub-import and adds a quick and dirty smoke-test to check for this (I may be overly cautious with this one).