### PR TITLE
Explicitly use fast-xml-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "astro": "^7.0.3",
+    "fast-xml-builder": "^1.3.0",
     "fast-xml-parser": "^5.3.3"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       astro:
         specifier: ^7.0.3
         version: 7.1.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@25.0.3)(rollup@4.62.0)
+      fast-xml-builder:
+        specifier: ^1.3.0
+        version: 1.3.0
       fast-xml-parser:
         specifier: ^5.3.3
         version: 5.10.1

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'astro/zod';
-import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+import { XMLParser } from 'fast-xml-parser';
+import XMLBuilder from 'fast-xml-builder';
 import { atomSchema, atomEntrySchema } from './schema.js';
 import { errorMap } from './util.js';
 import { defaultGenerator } from './generator.js';


### PR DESCRIPTION
Importing `XMLBuilder` from `fast-xml-parser` has been deprecated. This PR wires `fast-xml-builder` as an explicit dependency. 